### PR TITLE
Allow ignoring specific client_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ sensor:
 | **platform** | yes | | The sensor platform name.
 | **enable_notification** | no | `true` | Turn on/off `persistant_notifications` when a new IP is detected, can be `true`/`false`.
 | **exclude** | no | | A list of IP addresses you want to exclude.
-| **exclude_clients** | no | | A list of client_ids you want to exclude. For example, when using Alexa to connect to HA, you'll probably want to ignore pitangui.amazon.com (for North America), layla.amazon.com (EU/India) or alexa.amazon.co.jp (Far East), rather than IPs, of which there are hundred.
 | **provider** | no | 'ipapi' | The provider you want to use for GEO Lookup, 'ipapi', 'extreme', 'ipvigilante'.
 | **log_location** | no | | Full path to the logfile.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sensor:
 | **platform** | yes | | The sensor platform name.
 | **enable_notification** | no | `true` | Turn on/off `persistant_notifications` when a new IP is detected, can be `true`/`false`.
 | **exclude** | no | | A list of IP addresses you want to exclude.
-| **exclude_clients** | no | | A list of client_ids you want to exclude
+| **exclude_clients** | no | | A list of client_ids you want to exclude. For example, when using Alexa to connect to HA, you'll probably want to ignore pitangui.amazon.com (for North America), layla.amazon.com (EU/India) or alexa.amazon.co.jp (Far East), rather than IPs, of which there are hundred.
 | **provider** | no | 'ipapi' | The provider you want to use for GEO Lookup, 'ipapi', 'extreme', 'ipvigilante'.
 | **log_location** | no | | Full path to the logfile.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ sensor:
 | **platform** | yes | | The sensor platform name.
 | **enable_notification** | no | `true` | Turn on/off `persistant_notifications` when a new IP is detected, can be `true`/`false`.
 | **exclude** | no | | A list of IP addresses you want to exclude.
+| **exclude_clients** | no | | A list of client_ids you want to exclude
 | **provider** | no | 'ipapi' | The provider you want to use for GEO Lookup, 'ipapi', 'extreme', 'ipvigilante'.
 | **log_location** | no | | Full path to the logfile.
 

--- a/custom_components/authenticated/sensor.py
+++ b/custom_components/authenticated/sensor.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_NOTIFY = "enable_notification"
 CONF_EXCLUDE = "exclude"
+CONF_EXCLUDE_CLIENTS = "exclude_clients"
 CONF_PROVIDER = "provider"
 CONF_LOG_LOCATION = "log_location"
 
@@ -50,6 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_LOG_LOCATION, default=""): cv.string,
         vol.Optional(CONF_NOTIFY, default=True): cv.boolean,
         vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE_CLIENTS, default=[]): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -63,14 +65,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Create the sensor"""
     notify = config.get(CONF_NOTIFY)
     exclude = config.get(CONF_EXCLUDE)
+    exclude_clients = config.get(CONF_EXCLUDE_CLIENTS)
     hass.data[PLATFORM_NAME] = {}
 
-    if not load_authentications(hass.config.path(".storage/auth"), exclude):
+    if not load_authentications(hass.config.path(".storage/auth"), exclude, exclude_clients):
         return False
 
     out = str(hass.config.path(OUTFILE))
 
-    sensor = AuthenticatedSensor(hass, notify, out, exclude, config[CONF_PROVIDER])
+    sensor = AuthenticatedSensor(hass, notify, out, exclude, exclude_clients, config[CONF_PROVIDER])
     sensor.initial_run()
 
     add_devices([sensor], True)
@@ -79,7 +82,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AuthenticatedSensor(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, hass, notify, out, exclude, provider):
+    def __init__(self, hass, notify, out, exclude, exclude_clients, provider):
         """Initialize the sensor."""
         self.hass = hass
         self._state = None
@@ -87,13 +90,14 @@ class AuthenticatedSensor(Entity):
         self.stored = {}
         self.last_ip = None
         self.exclude = exclude
+        self.exclude_clients = exclude_clients
         self.notify = notify
         self.out = out
 
     def initial_run(self):
         """Run this at startup to initialize the platform data."""
         users, tokens = load_authentications(
-            self.hass.config.path(".storage/auth"), self.exclude
+            self.hass.config.path(".storage/auth"), self.exclude, self.exclude_clients
         )
 
         if os.path.isfile(self.out):
@@ -155,7 +159,7 @@ class AuthenticatedSensor(Entity):
         """Method to update sensor value"""
         updated = False
         users, tokens = load_authentications(
-            self.hass.config.path(".storage/auth"), self.exclude
+            self.hass.config.path(".storage/auth"), self.exclude, self.exclude_clients
         )
         _LOGGER.debug("Users %s", users)
         _LOGGER.debug("Access %s", tokens)
@@ -296,7 +300,7 @@ def get_hostname(ip_address):
     return hostname
 
 
-def load_authentications(authfile, exclude):
+def load_authentications(authfile, exclude, exclude_clients):
     """Load info from auth file."""
     if not os.path.exists(authfile):
         _LOGGER.critical("File is missing %s", authfile)
@@ -318,6 +322,8 @@ def load_authentications(authfile, exclude):
                     excludeaddress, False
                 ):
                     raise Exception("IP in excluded address configuration")
+            if token["client_id"] in exclude_clients:
+                raise Exception("Client in excluded clients configuration")
             if token.get("last_used_at") is None:
                 continue
             if token["last_used_ip"] in tokens_cleaned:


### PR DESCRIPTION
This can be very useful for ignoring things like Alexa logins, which
have a client_id of https://pitangui.amazon.com/ (for us-east-1 at
least)